### PR TITLE
Proper support for human and ansi render modes for Multiplexer

### DIFF
--- a/gym_multiplexer/multiplexer.py
+++ b/gym_multiplexer/multiplexer.py
@@ -14,7 +14,7 @@ class Multiplexer(gym.Env):
 
   def __init__(self, control_bits=3) -> None:
     self.control_bits = control_bits
-    self.metadata = {'render.modes': ['human']}
+    self.metadata = {'render.modes': ['human', 'ansi']}
 
     self._state = None
     self._validation_bit = 0
@@ -35,9 +35,11 @@ class Multiplexer(gym.Env):
 
   def render(self, mode='human'):
       if mode == 'human':
+          print(self._observation)
+      elif mode == 'ansi':
           return self._observation
-
-      return self.render(mode=mode)
+      else:
+          super(Multiplexer, self).render(mode=mode)
 
   @property
   def _observation(self) -> list:

--- a/gym_multiplexer/tests/test_boolean_multiplexer.py
+++ b/gym_multiplexer/tests/test_boolean_multiplexer.py
@@ -41,7 +41,7 @@ class TestBooleanMultiplexer:
         mp.reset()
 
         # when
-        state = mp.render()
+        state = mp.render('ansi')
 
         # then
         assert state is not None


### PR DESCRIPTION
`human` render mode shouldn't return anything, just print to the console.

`ansi` should return the string.

Reference: https://github.com/openai/gym/blob/master/gym/core.py#L84